### PR TITLE
Fix node label length - constraint error

### DIFF
--- a/components/esp_matter/esp_matter_attribute.h
+++ b/components/esp_matter/esp_matter_attribute.h
@@ -62,7 +62,7 @@ attribute_t *create_access_control_entries_per_fabric(cluster_t *cluster, uint16
 } /* access_control */
 
 namespace basic_information {
-constexpr uint8_t k_max_node_label_length = 32; 
+constexpr uint8_t k_max_node_label_length = 33; 
 
 namespace attribute {
 attribute_t *create_data_model_revision(cluster_t *cluster, uint16_t value);
@@ -243,7 +243,7 @@ attribute_t *create_time_since_reset(cluster_t *cluster, uint64_t value);
 } /* diagnostics_network_ethernet */
 
 namespace bridged_device_basic_information {
-constexpr uint8_t k_max_node_label_length = 32;
+constexpr uint8_t k_max_node_label_length = 33;
 
 namespace attribute {
 attribute_t *create_vendor_name(cluster_t *cluster, char *value, uint16_t length);

--- a/components/esp_matter/esp_matter_cluster.h
+++ b/components/esp_matter/esp_matter_cluster.h
@@ -70,7 +70,7 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags);
 namespace basic_information {
 typedef struct config {
     uint16_t cluster_revision;
-    char node_label[32];
+    char node_label[33];
     config() : cluster_revision(2), node_label{0} {}
 } config_t;
 


### PR DESCRIPTION
# Changes

Change length of node label attribute for basic information cluster & bridged device basic information cluster.

# Issues

https://eltako.atlassian.net/browse/EMB-2300
https://eltako.atlassian.net/browse/QSW-5633