### PR TITLE
Add attribute changed callback to bridged device basic info cluster

### DIFF
--- a/components/esp_matter/esp_matter_cluster.cpp
+++ b/components/esp_matter/esp_matter_cluster.cpp
@@ -857,8 +857,10 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
 } /* time_synchronization */
 
 namespace bridged_device_basic_information {
-const function_generic_t *function_list = NULL;
-const int function_flags = CLUSTER_FLAG_NONE;
+const function_generic_t function_list[] = {
+    (function_generic_t) MatterBridgedDeviceBasicInformationClusterServerAttributeChangedCallback,
+};
+const int function_flags = CLUSTER_FLAG_ATTRIBUTE_CHANGED_FUNCTION;
 
 cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
 {


### PR DESCRIPTION
 # Changes 
 
Adding Bridged Device Basic Information Cluster Server Attribute Change Callback for reachable changed event.
 
# Motivation 
 
 Receive the Reachable Changed event as soon as a bridged device reachable state changes (f.e. removal of bridged device)
 
 # Implementation 
 
Adding attribute changed callback to function list of all bridged device basic information clusters. This way, as soon as the reachable attribut is changed - the corresponding reachableChanged event is triggered as well.
 
 # Testing 
 
 By hand
 1. Commission device
 2. chip-tool interactive start + subscribe to reachableChanged event on ep 11
 3. remove matter service device on ep 11
 4. see how the interactive terminal informs about the new reachable state.
