### PR TITLE
Remove addition of duplicated event list attr

### DIFF
--- a/components/esp_matter/esp_matter_cluster.cpp
+++ b/components/esp_matter/esp_matter_cluster.cpp
@@ -100,9 +100,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
 
         /* Attributes updated later */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
 
 	/* Attributes not managed internally */
         if (config) {
@@ -137,9 +134,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
         /* Attributes managed internally */
         global::attribute::create_cluster_revision(cluster, 1);
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
         attribute::create_action_list(cluster, NULL, 0, 0);
         attribute::create_endpoint_lists(cluster, NULL, 0, 0);
 
@@ -185,9 +179,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
 
         /* Attributes updated later */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
     
         /* Attributes not managed internally */
         if (config) {
@@ -226,9 +217,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
         attribute::create_data_model_revision(cluster, 0);
         attribute::create_location(cluster, NULL, 0);
         attribute::create_vendor_name(cluster, NULL, 0);
@@ -280,9 +268,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
         attribute::create_binding(cluster, NULL, 0, 0);
 
         /* Attributes not managed internally */
@@ -318,9 +303,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
 
         /* Attributes not managed internally */
         if (config) {
@@ -362,9 +344,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
         attribute::create_default_ota_providers(cluster, NULL, 0, 0);
 
         /* Attributes not managed internally */
@@ -410,9 +389,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
         attribute::create_regulatory_config(cluster, 0);
         attribute::create_location_capability(cluster, 0);
         attribute::create_basic_commissioning_info(cluster, NULL, 0, 0);
@@ -468,9 +444,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
         attribute::create_last_network_id(cluster, NULL, 0);
         attribute::create_last_connect_error_value(cluster, nullable<int32_t>());
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
 
         /* Attributes not managed internally */
         if (config) {
@@ -519,9 +492,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
         attribute::create_reboot_count(cluster, 0);
         attribute::create_test_event_triggers_enabled(cluster, 0);
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
 
         /* Attributes not managed internally */
         if (config) {
@@ -560,9 +530,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
         attribute::create_window_status(cluster, 0);
         attribute::create_admin_fabric_index(cluster, 0);
         attribute::create_admin_vendor_id(cluster, 0);
@@ -605,9 +572,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
         attribute::create_nocs(cluster, NULL, 0, 0);
         attribute::create_supported_fabrics(cluster, 0);
         attribute::create_commissioned_fabrics(cluster, 0);
@@ -662,9 +626,6 @@ cluster_t *create(endpoint_t *endpoint, uint8_t flags)
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
         global::attribute::create_cluster_revision(cluster, 0);
         attribute::create_group_key_map(cluster, NULL, 0, 0);
         attribute::create_group_table(cluster, NULL, 0, 0);
@@ -705,9 +666,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
         attribute::create_bssid(cluster, NULL, 0);
         attribute::create_security_type(cluster, nullable<uint8_t>());
         attribute::create_wifi_version(cluster, nullable<uint8_t>());
@@ -747,9 +705,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
         attribute::create_channel(cluster, nullable<uint16_t>(0));
         attribute::create_routing_role(cluster, nullable<uint8_t>(0));
         attribute::create_network_name(cluster, NULL, 0);
@@ -798,9 +753,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
 
 	/* Attributes managed internally */
 	global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-	global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
 
         /* Attributes not managed internally */
 	if (config) {
@@ -838,9 +790,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
 
         /* Attributes not managed internally */
         if (config) {
@@ -878,9 +827,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
 
         /* Attributes not managed internally */
         if (config) {
@@ -915,9 +861,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags, uint32_
 
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
         /** Attributes not managed internally **/
         if (config) {
             global::attribute::create_cluster_revision(cluster, config->cluster_revision);
@@ -1014,9 +957,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
         attribute::create_label_list(cluster, NULL, 0, 0);
 
         /* Attributes not managed internally */
@@ -1052,9 +992,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
         attribute::create_label_list(cluster, NULL, 0, 0);
 
         /* Attributes not managed internally */
@@ -1097,9 +1034,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
 
         /* Attributes not managed internally */
         if (config) {
@@ -1141,9 +1075,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 1);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
 
         /* Attributes not managed internally */
         if (config) {
@@ -1191,9 +1122,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
 
         /* Attributes not managed internally */
         if (config) {
@@ -1252,9 +1180,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags, uint32_
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
 
         /* Attributes not managed internally */
         if (config) {
@@ -1303,9 +1228,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags, uint32_
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
 
         /* Attributes not managed internally */
         if (config) {
@@ -1364,9 +1286,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags, uint32_
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
 
         /* Attributes not managed internally */
         if (config) {
@@ -1442,9 +1361,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
 
         /* Attributes not managed internally */
         if (config) {
@@ -1489,9 +1405,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags, uint32_
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
 
         /* Attributes not managed internally */
         if (config) {
@@ -1545,9 +1458,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
 
 	/* Attributes managed internally */
 	   global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-	   global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
 
         /* Attributes not managed internally */
 	if (config) {
@@ -1585,9 +1495,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-	global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
 	attribute::create_air_quality(cluster, 0);
 
         /* Attributes not managed internally */
@@ -1624,9 +1531,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
 	attribute::create_change_indication(cluster, 0);
 
         /* Attributes not managed internally */
@@ -1663,9 +1567,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-	global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
 	attribute::create_change_indication(cluster, 0);
 
         /* Attributes not managed internally */
@@ -1702,9 +1603,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-	global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
 	attribute::create_measurement_medium(cluster, 0);
 
         /* Attributes not managed internally */
@@ -1742,9 +1640,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-	global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
 
         /* Attributes not managed internally */
         if (config) {
@@ -1781,9 +1676,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-	global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
 
         /* Attributes not managed internally */
         if (config) {
@@ -1820,9 +1712,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-	global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
 
         /* Attributes not managed internally */
         if (config) {
@@ -1859,9 +1748,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-	global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
 
         /* Attributes not managed internally */
         if (config) {
@@ -1898,9 +1784,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-	global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
 
         /* Attributes not managed internally */
         if (config) {
@@ -1937,9 +1820,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-	global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
 
         /* Attributes not managed internally */
         if (config) {
@@ -1976,9 +1856,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-	global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
 
         /* Attributes not managed internally */
         if (config) {
@@ -2015,9 +1892,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-	global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
 
         /* Attributes not managed internally */
         if (config) {
@@ -2091,9 +1965,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-	global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
 	attribute::create_phase_list(cluster, NULL, 0, 0);
         attribute::create_current_phase(cluster, 0);
         attribute::create_operational_state_list(cluster, NULL, 0, 0);
@@ -2136,9 +2007,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-	global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
 
 	/* Attributes not managed internally */
         if (config) {
@@ -2178,9 +2046,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-	global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
         /* Attributes not managed internally */
         if (config) {
             global::attribute::create_cluster_revision(cluster, config->cluster_revision);
@@ -2215,9 +2080,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-	global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
 
         /* Attributes not managed internally */
         if (config) {
@@ -2254,8 +2116,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-        global::attribute::create_event_list(cluster, NULL, 0, 0);
-
 
         /* Attributes not managed internally */
         if (config) {
@@ -2291,9 +2151,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
     if (flags & CLUSTER_FLAG_SERVER) {
 	/* Attributes managed internally */
 	global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-	global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
 	attribute::create_expressed_state(cluster, 0);
 	attribute::create_battery_alert(cluster, 0);
 	attribute::create_test_in_progress(cluster, false);
@@ -2351,9 +2208,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
 
         /* Attributes not managed internally */
         if (config) {
@@ -2406,9 +2260,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags, uint32_
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
 
         /* Attributes not managed internally */
         if (config) {
@@ -2461,9 +2312,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
 
         /* Attributes not managed internally */
         if (config) {
@@ -2503,9 +2351,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
 
         /* Attributes not managed internally */
         if (config) {
@@ -2546,9 +2391,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
 
         /* Attributes not managed internally */
         if (config) {
@@ -2591,9 +2433,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
 
         /* Attributes not managed internally */
         if (config) {
@@ -2634,9 +2473,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
 
         /* Attributes not managed internally */
         if (config) {
@@ -2674,9 +2510,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes not managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
 
         if (config) {
             /* Attributes not managed internally */
@@ -2718,9 +2551,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags, uint32_
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes not managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
 
         if (config) {
             /* Attributes not managed internally */
@@ -2765,9 +2595,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
         /** Attributes not managed internally **/
         if (config) {
             global::attribute::create_cluster_revision(cluster, config->cluster_revision);
@@ -2808,9 +2635,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
         /** Attributes not managed internally **/
         if (config) {
             global::attribute::create_cluster_revision(cluster, config->cluster_revision);
@@ -2849,9 +2673,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
         /** Attributes not managed internally **/
         if (config) {
             global::attribute::create_cluster_revision(cluster, config->cluster_revision);
@@ -2895,9 +2716,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
 
         /** Attributes not managed internally **/
         if (config) {
@@ -2938,9 +2756,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags, uint32_
 
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
         attribute::create_supported_modes(cluster, NULL, 0, 0);
         /** Attributes not managed internally **/
         if (config) {
@@ -2987,9 +2802,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
 
         /* Attributes not managed internally */
         if (config) {
@@ -3027,9 +2839,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags, uint32_
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
 
         /* Attributes not managed internally */
         if (config) {
@@ -3066,9 +2875,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags, uint32_
 
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
 
         /* Attributes not managed internally */
         if (config) {
@@ -3115,9 +2921,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
 
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
 
         /* Attributes not managed internally */
         if (config) {
@@ -3151,9 +2954,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
         
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-	global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
 	attribute::create_supported_modes(cluster, NULL, 0, 0);
         
         /* Attributes not managed internally */
@@ -3189,7 +2989,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
      
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-        global::attribute::create_event_list(cluster, NULL, 0, 0);
         attribute::create_supported_modes(cluster, NULL, 0, 0);
      
         /* Attributes not managed internally */
@@ -3230,9 +3029,6 @@ cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags)
     if (flags & CLUSTER_FLAG_SERVER) {
         /* Attributes managed internally */
         global::attribute::create_feature_map(cluster, 0);
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-	global::attribute::create_event_list(cluster, NULL, 0, 0);
-#endif
 
         /* Attributes not managed internally */
         if (config) {


### PR DESCRIPTION
The event list attribute is already added in the connected home over ip repository. This commit removes the addition of the event list attribute in the esp_matter_cluster.cpp file.

This issue solves TC-IDM-10.1 duplicated attribute "event-list"

Before this commit all attribute-lists had the event list attribute twice.
After this commit it should exist only once per cluster.

`chip-tool <clustername> read attribute-list <node-id> <endpoint-id> `

https://eltako.atlassian.net/browse/EMB-2457

https://eltako.atlassian.net/browse/EMB-2455
