### PR TITLE
Remove provisional scenes cluster

### DIFF
--- a/components/esp_matter/esp_matter_endpoint.cpp
+++ b/components/esp_matter/esp_matter_endpoint.cpp
@@ -155,7 +155,6 @@ esp_err_t add(endpoint_t *endpoint, config_t *config)
     cluster_t *identify_cluster = identify::create(endpoint, &(config->identify), CLUSTER_FLAG_SERVER);
     identify::command::create_trigger_effect(identify_cluster);
     groups::create(endpoint, &(config->groups), CLUSTER_FLAG_SERVER);
-    scenes::create(endpoint, &(config->scenes), CLUSTER_FLAG_SERVER);
     on_off::create(endpoint, &(config->on_off), CLUSTER_FLAG_SERVER, on_off::feature::lighting::get_id());
 
     return ESP_OK;
@@ -197,7 +196,6 @@ esp_err_t add(endpoint_t *endpoint, config_t *config)
     cluster_t *identify_cluster = identify::create(endpoint, &(config->identify), CLUSTER_FLAG_SERVER);
     identify::command::create_trigger_effect(identify_cluster);
     groups::create(endpoint, &(config->groups), CLUSTER_FLAG_SERVER);
-    scenes::create(endpoint, &(config->scenes), CLUSTER_FLAG_SERVER);
     on_off::create(endpoint, &(config->on_off), CLUSTER_FLAG_SERVER, on_off::feature::lighting::get_id());
     level_control::create(endpoint, &(config->level_control), CLUSTER_FLAG_SERVER,
                           level_control::feature::on_off::get_id() | level_control::feature::lighting::get_id());
@@ -240,7 +238,6 @@ esp_err_t add(endpoint_t *endpoint, config_t *config)
     cluster_t *identify_cluster = identify::create(endpoint, &(config->identify), CLUSTER_FLAG_SERVER);
     identify::command::create_trigger_effect(identify_cluster);
     groups::create(endpoint, &(config->groups), CLUSTER_FLAG_SERVER);
-    scenes::create(endpoint, &(config->scenes), CLUSTER_FLAG_SERVER);
     on_off::create(endpoint, &(config->on_off), CLUSTER_FLAG_SERVER, on_off::feature::lighting::get_id());
     level_control::create(endpoint, &(config->level_control), CLUSTER_FLAG_SERVER,
                           level_control::feature::on_off::get_id() | level_control::feature::lighting::get_id());
@@ -286,10 +283,6 @@ esp_err_t add(endpoint_t *endpoint, config_t *config)
     cluster_t *identify_cluster = identify::create(endpoint, &(config->identify), CLUSTER_FLAG_SERVER);
     identify::command::create_trigger_effect(identify_cluster);
     groups::create(endpoint, &(config->groups), CLUSTER_FLAG_SERVER);
-    cluster_t *scenes_cluster = scenes::create(endpoint, &(config->scenes), CLUSTER_FLAG_SERVER);
-    scenes::command::create_enhanced_add_scene(scenes_cluster);
-    scenes::command::create_enhanced_view_scene(scenes_cluster);
-    scenes::command::create_copy_scene(scenes_cluster);
 
     on_off::create(endpoint, &(config->on_off), CLUSTER_FLAG_SERVER, on_off::feature::lighting::get_id());
     level_control::create(endpoint, &(config->level_control), CLUSTER_FLAG_SERVER,
@@ -494,7 +487,6 @@ esp_err_t add(endpoint_t *endpoint, config_t *config)
     cluster_t *identify_cluster = identify::create(endpoint, &(config->identify), CLUSTER_FLAG_SERVER);
     identify::command::create_trigger_effect(identify_cluster);
     groups::create(endpoint, &(config->groups), CLUSTER_FLAG_SERVER);
-    scenes::create(endpoint, &(config->scenes), CLUSTER_FLAG_SERVER);
     on_off::create(endpoint, &(config->on_off), CLUSTER_FLAG_SERVER, on_off::feature::lighting::get_id());
 
     return ESP_OK;
@@ -535,7 +527,6 @@ esp_err_t add(endpoint_t *endpoint, config_t *config)
     cluster_t *identify_cluster = identify::create(endpoint, &(config->identify), CLUSTER_FLAG_SERVER);
     identify::command::create_trigger_effect(identify_cluster);
     groups::create(endpoint, &(config->groups), CLUSTER_FLAG_SERVER);
-    scenes::create(endpoint, &(config->scenes), CLUSTER_FLAG_SERVER);
     on_off::create(endpoint, &(config->on_off), CLUSTER_FLAG_SERVER, on_off::feature::lighting::get_id());
     level_control::create(endpoint, &(config->level_control), CLUSTER_FLAG_SERVER,
                           level_control::feature::on_off::get_id() | level_control::feature::lighting::get_id());
@@ -963,7 +954,6 @@ esp_err_t add(endpoint_t *endpoint, config_t *config)
     descriptor::create(endpoint, &(config->descriptor), CLUSTER_FLAG_SERVER);
     identify::create(endpoint, &(config->identify), CLUSTER_FLAG_SERVER);
     groups::create(endpoint, &(config->groups), CLUSTER_FLAG_SERVER);
-    scenes::create(endpoint, &(config->scenes), CLUSTER_FLAG_SERVER);
     window_covering::create(endpoint, &(config->window_covering), CLUSTER_FLAG_SERVER, ESP_MATTER_NONE_FEATURE_ID);
 
     return ESP_OK;

--- a/components/esp_matter/esp_matter_endpoint.h
+++ b/components/esp_matter/esp_matter_endpoint.h
@@ -147,7 +147,6 @@ typedef struct config {
     cluster::descriptor::config_t descriptor;
     cluster::identify::config_t identify;
     cluster::groups::config_t groups;
-    cluster::scenes::config_t scenes;
     cluster::on_off::config_t on_off;
 } config_t;
 
@@ -162,7 +161,6 @@ typedef struct config {
     cluster::descriptor::config_t descriptor;
     cluster::identify::config_t identify;
     cluster::groups::config_t groups;
-    cluster::scenes::config_t scenes;
     cluster::on_off::config_t on_off;
     cluster::level_control::config_t level_control;
 } config_t;
@@ -178,7 +176,6 @@ typedef struct config {
     cluster::descriptor::config_t descriptor;
     cluster::identify::config_t identify;
     cluster::groups::config_t groups;
-    cluster::scenes::config_t scenes;
     cluster::on_off::config_t on_off;
     cluster::level_control::config_t level_control;
     cluster::color_control::config_t color_control;
@@ -195,7 +192,6 @@ typedef struct config {
     cluster::descriptor::config_t descriptor;
     cluster::identify::config_t identify;
     cluster::groups::config_t groups;
-    cluster::scenes::config_t scenes;
     cluster::on_off::config_t on_off;
     cluster::level_control::config_t level_control;
     cluster::color_control::config_t color_control;
@@ -264,7 +260,6 @@ typedef struct config {
     cluster::descriptor::config_t descriptor;
     cluster::identify::config_t identify;
     cluster::groups::config_t groups;
-    cluster::scenes::config_t scenes;
     cluster::on_off::config_t on_off;
 } config_t;
 
@@ -279,7 +274,6 @@ typedef struct config {
     cluster::descriptor::config_t descriptor;
     cluster::identify::config_t identify;
     cluster::groups::config_t groups;
-    cluster::scenes::config_t scenes;
     cluster::on_off::config_t on_off;
     cluster::level_control::config_t level_control;
 } config_t;
@@ -308,7 +302,6 @@ namespace thermostat {
 typedef struct config {
     cluster::descriptor::config_t descriptor;
     cluster::identify::config_t identify;
-    cluster::scenes::config_t scenes;
     cluster::groups::config_t groups;
     cluster::thermostat::config_t thermostat;
 } config_t;
@@ -422,7 +415,6 @@ typedef struct config {
     cluster::descriptor::config_t descriptor;
     cluster::identify::config_t identify;
     cluster::groups::config_t groups;
-    cluster::scenes::config_t scenes;
     cluster::window_covering::config_t window_covering;
     config(uint8_t end_product_type = 0) : window_covering(end_product_type) {}
 } config_t;


### PR DESCRIPTION
 # Changes 
 
Removes provisional scenes cluster from all supported matter device types.

Lourens Koopmans from TÜV Rheinland has informed us:

> Scenes with ID 0x0005 shall never be implemented into any Matter device , only Scenes Management cluster 0x0062 is allowed in Matter v1.3 and higher

https://csamembers.slack.com/archives/C05G8PJ9F9T/p1717408193076569?thread_ts=1717407406.315829&cid=C05G8PJ9F9T
 
 # Issues: 
 
 Not tracked

# Motivation 
 
Succesful certification under Matter 1.2
 
 # Implementation 
 
Remove addition of scenes cluster from all matter device types
 
 # Testing 
 
 hand tested if on off plugin unit still has server cluster after flashing this commit.
 
 # Release Notes
 
 [matter] Removes provisional scenes cluster (0x0005) from all supported matter device types.