### PR TITLE
[matter] fix bug with default minimum value for temperature sensor

### DIFF
--- a/components/esp_matter/esp_matter_cluster.h
+++ b/components/esp_matter/esp_matter_cluster.h
@@ -591,7 +591,7 @@ typedef struct config {
     nullable<int16_t> measured_value;
     nullable<int16_t> min_measured_value;
     nullable<int16_t> max_measured_value;
-    config() : cluster_revision(4), measured_value(), min_measured_value(27315), max_measured_value(32767) {}
+    config() : cluster_revision(4), measured_value(), min_measured_value(-27315), max_measured_value(32767) {}
 } config_t;
 
 cluster_t *create(endpoint_t *endpoint, config_t *config, uint8_t flags);


### PR DESCRIPTION
 # Changes 
 
Fixes bug for default minimum measured value attribute not being the negative number, but instead the positive number.
 
 # Release Notes 
 
[matter] fix bug with default minimum value for temperature sensor