### PR TITLE
Fix indentify types

### DIFF
--- a/components/esp_matter/esp_matter_endpoint.cpp
+++ b/components/esp_matter/esp_matter_endpoint.cpp
@@ -527,9 +527,7 @@ esp_err_t add(endpoint_t *endpoint, config_t *config)
         return err;
     }
 
-    identify::config_t identify_config;
-    identify_config.identify_type = chip::to_underlying(Identify::IdentifyTypeEnum::kVisibleIndicator);
-    identify::create(endpoint, &identify_config, CLUSTER_FLAG_SERVER);
+    identify::create(endpoint, &(config->identify), CLUSTER_FLAG_SERVER);
     switch_cluster::create(endpoint, &(config->switch_cluster), CLUSTER_FLAG_SERVER);
 
     return ESP_OK;
@@ -561,9 +559,7 @@ esp_err_t add(endpoint_t *endpoint, config_t *config)
         return err;
     }
 
-    identify::config_t identify_config;
-    identify_config.identify_type = chip::to_underlying(Identify::IdentifyTypeEnum::kVisibleIndicator);
-    cluster_t *identify_cluster = identify::create(endpoint, &identify_config, CLUSTER_FLAG_SERVER);
+    cluster_t *identify_cluster = identify::create(endpoint, &(config->identify), CLUSTER_FLAG_SERVER);
     identify::command::create_trigger_effect(identify_cluster);
     groups::create(endpoint, &(config->groups), CLUSTER_FLAG_SERVER);
     on_off::create(endpoint, &(config->on_off), CLUSTER_FLAG_SERVER, on_off::feature::lighting::get_id());
@@ -777,9 +773,7 @@ esp_err_t add(endpoint_t *endpoint, config_t *config)
 	return err;
     }
 
-    identify::config_t identify_config;
-    identify_config.identify_type = chip::to_underlying(Identify::IdentifyTypeEnum::kVisibleIndicator);
-    identify::create(endpoint, &identify_config, CLUSTER_FLAG_SERVER);
+    identify::create(endpoint, &(config->identify), CLUSTER_FLAG_SERVER);
     air_quality::create(endpoint, &(config->air_quality), CLUSTER_FLAG_SERVER);
 
     return ESP_OK;
@@ -938,9 +932,7 @@ esp_err_t add(endpoint_t * endpoint, config_t * config)
 	    return err;
     }
 
-    identify::config_t identify_config;
-    identify_config.identify_type = chip::to_underlying(Identify::IdentifyTypeEnum::kAudibleBeep);
-    identify::create(endpoint, &identify_config, CLUSTER_FLAG_SERVER);
+    identify::create(endpoint, &(config->identify), CLUSTER_FLAG_SERVER);
     cluster::smoke_co_alarm::create(endpoint, &(config->smoke_co_alarm), CLUSTER_FLAG_SERVER);
 
     return ESP_OK;
@@ -1085,9 +1077,7 @@ esp_err_t add(endpoint_t *endpoint, config_t *config)
         return err;
     }
 
-    identify::config_t identify_config;
-    identify_config.identify_type = chip::to_underlying(Identify::IdentifyTypeEnum::kVisibleIndicator);
-    identify::create(endpoint, &identify_config, CLUSTER_FLAG_SERVER);
+    identify::create(endpoint, &(config->identify), CLUSTER_FLAG_SERVER);
     temperature_measurement::create(endpoint, &(config->temperature_measurement), CLUSTER_FLAG_SERVER);
 
     return ESP_OK;
@@ -1119,9 +1109,7 @@ esp_err_t add(endpoint_t *endpoint, config_t *config)
         return err;
     }
 
-    identify::config_t identify_config;
-    identify_config.identify_type = chip::to_underlying(Identify::IdentifyTypeEnum::kVisibleIndicator);
-    identify::create(endpoint, &identify_config, CLUSTER_FLAG_SERVER);
+    identify::create(endpoint, &(config->identify), CLUSTER_FLAG_SERVER);
     relative_humidity_measurement::create(endpoint, &(config->relative_humidity_measurement), CLUSTER_FLAG_SERVER);
 
     return ESP_OK;
@@ -1153,9 +1141,7 @@ esp_err_t add(endpoint_t *endpoint, config_t *config)
         return err;
     }
 
-    identify::config_t identify_config;
-    identify_config.identify_type = chip::to_underlying(Identify::IdentifyTypeEnum::kVisibleIndicator);
-    identify::create(endpoint, &identify_config, CLUSTER_FLAG_SERVER);
+    identify::create(endpoint, &(config->identify), CLUSTER_FLAG_SERVER);
     occupancy_sensing::create(endpoint, &(config->occupancy_sensing), CLUSTER_FLAG_SERVER);
 
     return ESP_OK;
@@ -1187,9 +1173,7 @@ esp_err_t add(endpoint_t *endpoint, config_t *config)
         return err;
     }
 
-    identify::config_t identify_config;
-    identify_config.identify_type = chip::to_underlying(Identify::IdentifyTypeEnum::kVisibleIndicator);
-    identify::create(endpoint, &identify_config, CLUSTER_FLAG_SERVER);
+    identify::create(endpoint, &(config->identify), CLUSTER_FLAG_SERVER);
     cluster_t * cluster = boolean_state::create(endpoint, &(config->boolean_state), CLUSTER_FLAG_SERVER);
     boolean_state::event::create_state_change(cluster);
 
@@ -1222,9 +1206,7 @@ esp_err_t add(endpoint_t *endpoint, config_t *config)
         return err;
     }
 
-    identify::config_t identify_config;
-    identify_config.identify_type = chip::to_underlying(Identify::IdentifyTypeEnum::kVisibleIndicator);
-    identify::create(endpoint, &identify_config, CLUSTER_FLAG_SERVER);
+    identify::create(endpoint, &(config->identify), CLUSTER_FLAG_SERVER);
     illuminance_measurement::create(endpoint, &(config->illuminance_measurement), CLUSTER_FLAG_SERVER);
 
     return ESP_OK;
@@ -1597,10 +1579,8 @@ esp_err_t add(endpoint_t *endpoint, config_t *config)
         ESP_LOGE(TAG, "Failed to add device type id:%" PRIu32 ",err: %d", get_device_type_id(), err);
         return err;
     }
-
-    identify::config_t identify_config;
-    identify_config.identify_type = chip::to_underlying(Identify::IdentifyTypeEnum::kVisibleIndicator);
-    identify::create(endpoint, &identify_config, CLUSTER_FLAG_SERVER);
+    
+    identify::create(endpoint, &(config->identify), CLUSTER_FLAG_SERVER);
     boolean_state::create(endpoint, &(config->boolean_state), CLUSTER_FLAG_SERVER);
 
     return ESP_OK;
@@ -1666,9 +1646,7 @@ esp_err_t add(endpoint_t *endpoint, config_t *config)
         return err;
     }
 
-    identify::config_t identify_config;
-    identify_config.identify_type = chip::to_underlying(Identify::IdentifyTypeEnum::kVisibleIndicator);
-    identify::create(endpoint, &identify_config, CLUSTER_FLAG_SERVER);
+    identify::create(endpoint, &(config->identify), CLUSTER_FLAG_SERVER);
     cluster_t *cluster = boolean_state::create(endpoint, &(config->boolean_state), CLUSTER_FLAG_SERVER);
 
     boolean_state::event::create_state_change(cluster);


### PR DESCRIPTION
Update device type add() functions to use identify config parameters instead of hard-coded values